### PR TITLE
update to the new Webpack API

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -29,7 +29,7 @@ class SpawnPlugin {
   }
 
   apply(compiler: any) {
-    compiler.plugin(this.when, () => {
+    compiler.hooks[this.when].tap({ name: 'webpack-spawn-plugin' }, () => {
       const promise = this.pid ? kill(this.pid) : Promise.resolve()
       const doSpawn = () => {
         const server = spawn(...this.args)


### PR DESCRIPTION
This plugin is currently using deprecated APIs.
This PR makes the small update necessary to update to the new APIs (see https://webpack.js.org/api/compiler-hooks/#hooks) and remove the deprecation messages thrown by Webpack.