### PR TITLE
Adds a 'persistent' option to the plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,10 +18,28 @@ import SpawnPlugin from 'webpack-spawn-plugin'
 const config = {
   ...
   plugins: [
-    new SpawnPlugin('node', ['.'], { when: 'done', stdio: 'inherit' }) // default values for `when` and `stdio`
+    new SpawnPlugin('node', ['.'], options)
   ]
 }
 ```
+
+### Options
+
+> `when` (default: "done")
+
+The [Webpack compiler hook](https://webpack.js.org/api/compiler-hooks/#hooks)
+during which the process will be spawned.
+
+> `stdio` (default: "inherit")
+
+The output stream to which stdout and stderr will be sent.
+
+> `persistent` (default: false)
+
+Indicates whether the spawned process should be replaced
+every time the hook is called.
+
+**Note**: You can pass more options to process.spawn in the `options` objects.
 
 ## License
 

--- a/src/index.js
+++ b/src/index.js
@@ -5,25 +5,39 @@ import fkill from 'fkill'
 type Options = {
   when: string,
   stdio: string,
+  persistent: boolean
 }
 
 class SpawnPlugin {
   pid: any
   when: string
+  persistent: boolean
   args: any[]
 
   constructor(
     command: string,
     args: any[] = [],
-    { when = 'done', stdio = 'inherit', ...options }: Options = {}
+    {
+      when = 'done',
+      stdio = 'inherit',
+      persistent = false,
+      ...options
+    }: Options = {}
   ) {
     this.when = when
+    this.persistent = persistent
     this.args = [command, args, { stdio, ...options }]
   }
 
   apply(compiler: any) {
     compiler.hooks[this.when].tap({ name: 'webpack-spawn-plugin' }, () => {
-      const promise = this.pid ? fkill(this.pid) : Promise.resolve()
+      let promise = Promise.resolve()
+      if (this.pid) {
+        if (this.persistent) {
+          return
+        }
+        promise = fkill(this.pid)
+      }
       const doSpawn = () => {
         const server = spawn(...this.args)
         this.pid = server.pid


### PR DESCRIPTION
This allows Webpack to start persistent processes.
This is very useful for instance to start side servers, for example.

Documentation has been added and a bit revamped, I hope that'll be to your taste :)